### PR TITLE
fixed misplaced asterisk - 2 (ROM)

### DIFF
--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM** (read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM **( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 


### PR DESCRIPTION
Referencing [this](https://github.com/salmoneatenbybear/circuitverse-docs/issues/3)
Fixing Misplaced asterisk in Chapter 4 ``6sequentialelements.mdx`` **ROM** section.



# Before
![issue1_before](https://github.com/user-attachments/assets/89099dec-3921-4bb0-8774-cc0ea512866d)
# After

![issue1_after](https://github.com/user-attachments/assets/d4e8cca6-411a-473f-b2f6-e74067309d7a)
