### PR TITLE
fixed misplaced asterisk - 1 (CLOCK)

### DIFF
--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM** (read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -481,7 +481,7 @@ You can verify the behavior of the **Keyboard** circuit element in the live circ
 
 ## Clock
 
-The **Clock **circuit element toggles its output at regular time intervals.
+The **Clock** circuit element toggles its output at regular time intervals.
 
 > NOTE: All clocks enabled within a circuit toggle at the same rate.
 

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM **( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 


### PR DESCRIPTION
Referencing [this](https://github.com/salmoneatenbybear/circuitverse-docs/issues/3)

Misplaced (*) in the **CLOCK** section of chapter 4 ``6sequentialelementx.mdx``

# Before
![issue2_before](https://github.com/user-attachments/assets/f9391049-1c74-465b-9044-1d59d3e6e2a6)

# After

![issue2_after](https://github.com/user-attachments/assets/03032d28-0e33-41a2-b9da-381ff0620142)
