### PR TITLE
fixed misplaced asterisk - 3 (RAM)

### DIFF
--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -533,7 +533,7 @@ Alternatively, the contents of the RAM can be dumped to the console by transitio
   </em>
 </div>
 
-You can verify the behavior of the **RAM **circuit element in the live circuit embedded below:
+You can verify the behavior of the **RAM** circuit element in the live circuit embedded below:
 
 <iframe
   width="600px"

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM** (read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM **( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 


### PR DESCRIPTION
Referencing [this](https://github.com/salmoneatenbybear/circuitverse-docs/issues/5)

Misplaced asterisk in chapter 4 ``6sequentialelements.mdx`` **RAM** section.

# Before
![issue3_before](https://github.com/user-attachments/assets/a87eb332-e05f-4264-9ddf-4c5b7557e7f2)

# After

![issue3_after](https://github.com/user-attachments/assets/0d050ba4-d8c6-46fb-b026-fc32c3803ae3)
