### PR TITLE
fixed misplaced asterisk - 4 (HEX-DISPLAY)

### DIFF
--- a/docs/chapter4/3output.mdx
+++ b/docs/chapter4/3output.mdx
@@ -132,7 +132,7 @@ The live circuit embedded below illustrates how an array of pixels may be progra
 
 ## HexDisplay
 
-The **HexDisplay** is more simple to use than the** SevenSegDisplay** and **SixteenSegDisplay **circuit elements. Since it takes a 4-bit input and can display integers 1 through 9 and the letters A through F, there is less room for customization.
+The **HexDisplay** is more simple to use than the **SevenSegDisplay** and **SixteenSegDisplay** circuit elements. Since it takes a 4-bit input and can display integers 1 through 9 and the letters A through F, there is less room for customization.
 
 The input bits do not control the individual segments ( as it is not possible to control six segments with only four bits). The hex display simply recognizes the integer/letter that a given input corresponds to and displays the character. The display character thus does not need to be programmed.
 

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -533,7 +533,7 @@ Alternatively, the contents of the RAM can be dumped to the console by transitio
   </em>
 </div>
 
-You can verify the behavior of the **RAM **circuit element in the live circuit embedded below:
+You can verify the behavior of the **RAM** circuit element in the live circuit embedded below:
 
 <iframe
   width="600px"

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM** (read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 

--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -489,7 +489,7 @@ You can verify the behavior of the **Clock** circuit element in the live circuit
 
 ## ROM
 
-As the name suggests, the **ROM **( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
+As the name suggests, the **ROM**( read-only memory) circuit element stores read only data for computers and other electronic devices. ROM is mostly used for firmware updates. A simple example of ROM is the cartridge used with video game consoles, which allows one system to run multiple games. Another example of ROM is EEPROM, which is a programmable ROM used for the computer BIOS.
 
 The **ROM** circuit element includes three pins. As Figure 4.10 elucidates, it accepts a 4-bit address input (**A**) and the corresponding value stored in the particular address is returned as a 8-bit output (**D**) (initial address always starts from 0). The Enable (**En**) pin enables the ROM.
 


### PR DESCRIPTION
Referencing [this](https://github.com/salmoneatenbybear/circuitverse-docs/issues/6) issue.

Misplaced (*) in chapter 4 ``output.mdx`` **HEX-DISPLAY** section.

# Before
![issue4_before](https://github.com/user-attachments/assets/e6561433-78a3-4d23-afb4-8ad9879d7290)

# After
![issue4_after](https://github.com/user-attachments/assets/049f483f-f637-4dc6-8eba-66b25ec8a2f4)
