### PR TITLE
fixed additional visible asterisks in D-Latch section

### DIFF
--- a/docs/chapter4/6sequentialelements.mdx
+++ b/docs/chapter4/6sequentialelements.mdx
@@ -88,7 +88,7 @@ You can verify the behavior of the D Flip Flop circuit element in the live circu
 
 The **D Latch** circuit element is a single input flip flop. As Figure 4.4, it works similar to a **D Flip Flop** but it does not include the preset, asynchronous and enable signal pins. The truth table of a D Latch (refer Table 4.13) is similar to that of the D Flip Flop.
 
-> Properties that can be customized in the **PROPERTIES** panel include:\*\* **BitWidth**
+> Properties that can be customized in the **PROPERTIES** panel include: **BitWidth**
 
 ![](/img/img_chapter4/4.4.png)
 


### PR DESCRIPTION
Referencing [this](https://github.com/salmoneatenbybear/circuitverse-docs/issues/7) issue.

Additional visible asterisks in chapter 4 ``output.mdx`` **D-LATCH** section.

# Before
![issue5_before](https://github.com/user-attachments/assets/8280377a-484a-4132-b600-21ce096374b7)

# After
![issue5_after](https://github.com/user-attachments/assets/95c81891-f2a0-4da4-9c53-3f9e16226424)
