### PR TITLE
Fix youtube iframe to limit its width and mantain aspect ratio

### DIFF
--- a/docs/chapter3/1introduction.mdx
+++ b/docs/chapter3/1introduction.mdx
@@ -8,10 +8,8 @@ description: "Introduction page in Chapter3 of CircuitVerse documentation."
 
 The CircuitVerse simulator includes different sections for building and managing circuit simulations. Watch the below video for a quick demonstration of how you can build and simulate your circuits using different features and workflows available within the CV platform.
 
-<div>
+<div class="responsive-iframe">
   <iframe
-    width="1424"
-    height="592"
     src="https://www.youtube.com/embed/F-_uvYJK938"
     title="YouTube video player"
     frameborder="0"

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -105,3 +105,8 @@ div[style="overflow: auto"]{
     width: 296px;
   }  
 }
+
+.responsive-iframe iframe{
+  width: 100%;
+  aspect-ratio: 16 / 9; 
+}


### PR DESCRIPTION
Changes Made:

Added width: 100% to ensure the iframe takes up the full width of its container.
Applied aspect-ratio: 16 / 9 to maintain the correct 16:9 aspect ratio for the iframe, ensuring it scales appropriately across different devices and screen sizes.

Testing Done:

Tested the iframe on various screen sizes (desktop, tablet, and mobile).
Verified that the iframe adapts smoothly without horizontal scrolling or distortion.

Linked to #24 
