### PR TITLE
fixed youtube iframe at introduciton page

### DIFF
--- a/docs/chapter1/1introduction.mdx
+++ b/docs/chapter1/1introduction.mdx
@@ -53,10 +53,8 @@ As the CircuitVerse community grows, educators and students can join the online 
 
 Watch the below video for a quick demonstration of the CircuitVerse platform.
 
-<div>
+<div class="responsive-iframe">
   <iframe
-    width="500px"
-    height="400px"
     src="https://www.youtube.com/embed/3Df-2Cn_80A"
     frameborder="0"
     scrolling="no"


### PR DESCRIPTION
Changes Made:

Added width: 100% to ensure the iframe takes up the full width of its container.
Applied aspect-ratio: 16 / 9 to maintain the correct 16:9 aspect ratio for the iframe, ensuring it scales appropriately across different devices and screen sizes.

Testing Done:

Tested the iframe on various screen sizes (desktop, tablet, and mobile).
Verified that the iframe adapts smoothly without horizontal scrolling or distortion.

for smartphones after the fix
![f4464c26-5ca7-411d-a720-3b3d00287fc4](https://github.com/user-attachments/assets/79c24fd8-5c03-473b-96e1-a3007a5ca72c)

tablets:
before:
![Screenshot 2025-02-02 163919](https://github.com/user-attachments/assets/86076dbe-38e4-44af-a09c-a8fa3c64472b)
after:
![Screenshot 2025-02-02 165017](https://github.com/user-attachments/assets/b9c7d476-7c0b-4aac-b767-90402f2b672b)

PC's:
before:
![Screenshot 2025-02-02 164850](https://github.com/user-attachments/assets/892a5bb3-5852-4bc8-8928-be56dad6b466)
after:
![Screenshot 2025-02-02 165040](https://github.com/user-attachments/assets/df3528c5-d916-4fed-ad5b-bff282775ce1)

