### PR TITLE
fixed misplaced asterisks in properties panel

### DIFF
--- a/docs/chapter3/properties.mdx
+++ b/docs/chapter3/properties.mdx
@@ -6,7 +6,7 @@ description: "Properties page in Chapter3 of CircuitVerse documentation."
 
 # Properties Panel
 
-Each circuit element has some properties associated with itself which are displayed in the **PROPERTIES **panel. Besides including different parameters for creating multi-bit circuits, it also includes parameters for annotation. the circuit schematic can be annotated by:
+Each circuit element has some properties associated with itself which are displayed in the **PROPERTIES** panel. Besides including different parameters for creating multi-bit circuits, it also includes parameters for annotation. the circuit schematic can be annotated by:
 
 - Adding labels across different nodes.
 - Including text boxes for displaying the version number, date, amendments and different group members involved.
@@ -130,7 +130,7 @@ Table 3.7: Brief description of the different properties available for different
 
 ## Edit Circuit Layout
 
-As shown in Figure 3.14, the **Edit Layout **button available on the **PROPERTIES **panel converts the circuit into a black box. The circuit elements and the relevant connections are hidden whereas the input and output pins are displayed (in the same order as displayed in the main circuit ).
+As shown in Figure 3.14, the **Edit Layout** button available on the **PROPERTIES** panel converts the circuit into a black box. The circuit elements and the relevant connections are hidden whereas the input and output pins are displayed (in the same order as displayed in the main circuit ).
 
 ![drawing](/img/img_chapter3/3.14.png)
 


### PR DESCRIPTION
the asterisks in properties page of chapter 3 of Simulator Interface are misplaced at 3 places
![image](https://github.com/user-attachments/assets/a497a4ba-f9d7-4553-8de5-452ff439277b)
& 
![image](https://github.com/user-attachments/assets/39dcea9b-706b-4a7d-942c-3f589e2d9837)

After:
![image](https://github.com/user-attachments/assets/cbaa6e7f-1cb6-4a9a-bf8b-974a50a9aef2)
![image](https://github.com/user-attachments/assets/908e8bb1-9708-4ae5-99b9-177aa3fa0880)


