### PR TITLE
Fix missing iframe

### DIFF
--- a/docs/chapter2/2cvforeducators.mdx
+++ b/docs/chapter2/2cvforeducators.mdx
@@ -538,9 +538,15 @@ When the extension is successfully installed, it is displayed as an option in th
 
 Watch the below video for a quick demonstration of how the CircuitVerse Chrome extension works in Google Slides.
 
-[insert embed video]
-
-<div><iframe></iframe></div>
+<div class="responsive-iframe">
+  <iframe
+    src="https://www.youtube.com/embed/t8ULT-aGymo"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+    allowfullscreen
+  ></iframe>
+</div>
 
 ## Download Image
 

--- a/docs/chapter3/1introduction.mdx
+++ b/docs/chapter3/1introduction.mdx
@@ -13,7 +13,7 @@ The CircuitVerse simulator includes different sections for building and managing
     src="https://www.youtube.com/embed/F-_uvYJK938"
     title="YouTube video player"
     frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
     allowfullscreen
   ></iframe>
 </div>


### PR DESCRIPTION
Added missing link for iframe youtube embed at working with google slides with circuitverse extension in cv for educators page
please check if this is the correct video link : https://www.youtube.com/t8ULT-aGymo
before:
![image](https://github.com/user-attachments/assets/c294e6bb-10b0-4b62-acaf-0ae296a315dc)
after:
![image](https://github.com/user-attachments/assets/911204a9-ce25-4e9e-b2a4-0545500aefaa)


I have also solved the issue of youtube embeds with disabled fullscreen option
before:
![image](https://github.com/user-attachments/assets/2878c083-a202-4023-bc20-7adea0b08da2)
After:
![image](https://github.com/user-attachments/assets/6ef5d632-00cd-484b-b364-20023efc31c5)
Linked to #30 

